### PR TITLE
bugfix empty sequence error in periodbase

### DIFF
--- a/astrobase/periodbase/spdm.py
+++ b/astrobase/periodbase/spdm.py
@@ -276,8 +276,19 @@ def stellingwerf_pdm(times,
         finlsp = lsp[finitepeakind]
         finperiods = periods[finitepeakind]
 
-
-        bestperiodind = npargmin(finlsp)
+        # finlsp might not have any values. if so, argmin will return a ValueError.
+        try:
+            bestperiodind = npargmin(finlsp)
+        except ValueError:
+            LOGERROR('no good detections for these times and mags, skipping...')
+            return {'bestperiod':npnan,
+                    'bestlspval':npnan,
+                    'nbestpeaks':nbestpeaks,
+                    'nbestlspvals':None,
+                    'nbestperiods':None,
+                    'lspvals':None,
+                    'periods':None,
+                    'method':'pdm'}
 
         sortedlspind = np.argsort(finlsp)
         sortedlspperiods = finperiods[sortedlspind]


### PR DESCRIPTION
Else, when `finlsp` has no entries (e.g., PDM returned only infs) you
get the following ValueError:

```
File
".../astrobase-0.1.0-py3.5.egg/astrobase/periodbase/spdm.py",
line 280, in stellingwerf_pdm
  bestperiodind = npargmin(finlsp)

File
".../site-packages/numpy/core/fromnumeric.py",
line 1034, in argmin
  return argmin(axis, out)
ValueError: attempt to get argmin of an empty sequence
```