### PR TITLE
lcproc: fix field_wcsfrom typo

### DIFF
--- a/astrobase/lcproc.py
+++ b/astrobase/lcproc.py
@@ -743,7 +743,7 @@ def make_lclist(basedir,
                 hdulist.close()
 
                 frameshape = (hdr['NAXIS1'], hdr['NAXIS2'])
-                w = WCS(wcsfrom)
+                w = WCS(field_wcsfrom)
                 wcsok = True
 
             else:

--- a/astrobase/lcproc.py
+++ b/astrobase/lcproc.py
@@ -736,9 +736,9 @@ def make_lclist(basedir,
                 w = WCS(hdr)
                 wcsok = True
 
-            elif os.path.exists(wcsfrom):
+            elif os.path.exists(field_wcsfrom):
 
-                hdulist = pyfits.open(field_fitsfile)
+                hdulist = pyfits.open(field_wcsfrom)
                 img, hdr = hdulist[0].data, hdulist[0].header
                 hdulist.close()
 


### PR DESCRIPTION
logic is:
* if you call `make_lclist` without any specific wcs file, get it from the `field_fitsfile`
* elif you call it with a specific wcs file, use the specific wcs file
* else raise error.