### PR TITLE
Syntax error fix for services/hatds.py

### DIFF
--- a/astrobase/services/hatds.py
+++ b/astrobase/services/hatds.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from __future__ import print_function
 
 '''hatds.py - Waqas Bhatti (wbhatti@astro.princeton.edu) - Apr 2017
 License: MIT - see LICENSE for the full text.
@@ -75,7 +76,6 @@ __version__ = '0.3.14'
 ## LOGGING ##
 #############
 
-from __future__ import print_function
 import logging
 from datetime import datetime
 from traceback import format_exc
@@ -232,9 +232,10 @@ def check_apikey_settings():
 
             return HAVEAPIKEY, None, None
     else:
-        LOGWARNING('No HAT Data Server API credentials found in: %s\n'
-                   'Only anonymous access is available.\n\n
-                   {apikeyhelp}'.format(apikeyhelp=APIKEYHELP))
+        LOGWARNING('No HAT Data Server API credentials found in: {apikeyfile}\n'
+                   'Only anonymous access is available.\n\n'
+                   '{apikeyhelp}'.format(apikeyfile=APIKEYFILE,
+                                         apikeyhelp=APIKEYHELP))
         HAVEAPIKEY = False
 
         return HAVEAPIKEY, None, None


### PR DESCRIPTION
Moved ``__future__`` statement and reformatted a string to avoid syntax errors during ``python setup.py install``