### PR TITLE
lcfit.mandel_agol_fit_magseries: save initial flux

### DIFF
--- a/astrobase/varbase/lcfit.py
+++ b/astrobase/varbase/lcfit.py
@@ -1871,6 +1871,7 @@ def mandelagol_fit_magseries(times, mags, errs,
         'fittype':'mandelagoltransit',
         'fitinfo':{
             'initialparams':fitparams,
+            'initialmags':init_flux,
             'fixedparams':fixedparams,
             'finalparams':medianparams,
             'finalparamerrs':stderrs,


### PR DESCRIPTION
sometimes it can be useful to know what the initial guesses looked like