### PR TITLE
add timeutils.get_epochs_given_midtimes_and_period

### DIFF
--- a/astrobase/timeutils.py
+++ b/astrobase/timeutils.py
@@ -266,6 +266,56 @@ def precess_coordinates(ra, dec,
         return np.degrees(raproc), np.degrees(decproc)
 
 
+############################
+## EPOCHS FOR EPHEMERIDES ##
+############################
+
+def get_epochs_given_midtimes_and_period(t_mid, period, t0_percentile=None,
+                                         verbose=False):
+    '''
+    t_mid = period*epoch + t0.
+
+    args:
+        t_mid (np.array): array of transit mid-time measurements
+
+        period (float): period used to calculate epochs, per the equation
+        above. for typical use cases, a period precise to ~1e-5 days is
+        sufficient to get correct epochs.
+
+    kwargs:
+        t0_percentile (optional float): if passed, uses this percentile
+        of t_mid to define t0.
+    '''
+
+    t_mid = t_mid[np.isfinite(t_mid)]
+    N_midtimes = len(t_mid)
+
+    if not t0_percentile:
+        # if there are an odd number of times, take the median time as epoch=0.
+        # elif there are an even number of times, take the lower of the two
+        # middle times as epoch=0.
+        if N_midtimes % 2 == 1:
+            t0 = np.median(t_mid)
+        else:
+            t0 = t_mid[int(N_midtimes/2)]
+    else:
+        t0 = np.percentile(t_mid, t0_percentile)
+
+    epoch = (t_mid - t0)/period
+
+    # do not convert numpy entries to actual ints, because np.nan is float type
+    int_epoch = np.round(epoch, 0)
+
+    if verbose:
+        LOGINFO('epochs before rounding')
+        LOGINFO('\n{:s}'.format(repr(epoch)))
+        LOGINFO('epochs after rounding')
+        LOGINFO('\n{:s}'.format(repr(int_epoch)))
+
+    return int_epoch, t0
+
+
+
 
 ###########################
 ## JULIAN DATE FUNCTIONS ##


### PR DESCRIPTION
this is a function I'm using enough in O-C analyses to probably merit
inclusion in astrobase!

output for some hot jupiter looks like:
```
[2018-11-17T21:28:33Z - INFO] epochs before rounding
[2018-11-17T21:28:33Z - INFO]
array([-1009.00224837,  -972.00275174,  -781.00255249,  -757.00164922,
        -686.00157302,  -511.00533079,  -509.00129477,  -509.00135769,
        -509.00127939,  -496.0013521 ,  -495.00467641,  -450.99885974,
        -435.00152128,  -435.00132064,  -428.00020764,  -302.0011899 ,
        -302.00126611,  -302.00082286,  -302.00074526,  -265.00076414,
        -265.00129337,  -265.00061732,  -230.00078162,  -230.00161287,
        -226.00287059,  -223.00123534,  -214.0018282 ,  -214.00029643,
        -184.00240078,  -174.99837804,  -160.99881429,     0.        ,
          16.00037333,    30.00010976,    31.99863672,    52.99747338,
          71.99843537,    76.00092144,   303.99839063,   317.99776421,
         496.99977768,   526.99827527,   531.99903032,   538.99931976,
        1039.00062072,  1039.99985442,  1041.00009306,  1041.99979561,
        1043.00142119,  1043.99936648,  1045.00087235,  1046.00055897,
        1046.99952124,  1048.9992327 ,  1050.00039681,  1051.00024242,
        1051.99957449,  1053.00024336,  1053.9992794 ,  1055.00101936,
        1056.00111892,  1056.99956115])
[2018-11-17T21:28:33Z - INFO] epochs after rounding
[2018-11-17T21:28:33Z - INFO]
array([-1009.,  -972.,  -781.,  -757.,  -686.,  -511.,  -509.,  -509.,
        -509.,  -496.,  -495.,  -451.,  -435.,  -435.,  -428.,  -302.,
        -302.,  -302.,  -302.,  -265.,  -265.,  -265.,  -230.,  -230.,
        -226.,  -223.,  -214.,  -214.,  -184.,  -175.,  -161.,     0.,
          16.,    30.,    32.,    53.,    72.,    76.,   304.,   318.,
         497.,   527.,   532.,   539.,  1039.,  1040.,  1041.,  1042.,
        1043.,  1044.,  1045.,  1046.,  1047.,  1049.,  1050.,  1051.,
        1052.,  1053.,  1054.,  1055.,  1056.,  1057.])
```