### PR TITLE
lcfit: fixed key bug in likelihood

### DIFF
--- a/astrobase/varbase/lcfit.py
+++ b/astrobase/varbase/lcfit.py
@@ -1567,7 +1567,7 @@ def _log_likelihood_transit(theta, params, model, t, flux, err_flux,
             params.a = theta[ix]
         elif key == 'incl':
             params.inc = theta[ix]
-        elif key == 'per':
+        elif key == 'period':
             params.per = theta[ix]
         elif key == 'ecc':
             params.per = theta[ix]
@@ -1609,7 +1609,7 @@ def _log_likelihood_transit_plus_line(theta, params, model, t, data_flux,
             params.a = theta[ix]
         elif key == 'incl':
             params.inc = theta[ix]
-        elif key == 'per':
+        elif key == 'period':
             params.per = theta[ix]
         elif key == 'ecc':
             params.per = theta[ix]


### PR DESCRIPTION
per the docstring, and everywhere else in the code, "period" is the key
used for the transit period, not "per".

this bug previously prevented sampling across the orbital period.

(usually I had left it as a fixed parameter, which is why this was not
noticed earlier).