### PR TITLE
lcfit: add python<3.3 compatability for lc fitting

### DIFF
--- a/astrobase/varbase/lcfit.py
+++ b/astrobase/varbase/lcfit.py
@@ -1891,15 +1891,40 @@ def mandelagol_fit_magseries(times, mags, errs,
                 +'{:d} threads'.format(nworkers)
             )
 
-        with Pool(nworkers) as pool:
-            sampler = emcee.EnsembleSampler(
-                n_walkers, n_dim, log_posterior_transit,
-                args=(init_params, init_m, stimes, smags, serrs, priorbounds),
-                pool=pool,
-                backend=backend
-            )
-            sampler.run_mcmc(starting_positions, n_mcmc_steps,
-                             progress=mcmcprogressbar)
+        import sys
+
+        if sys.version_info >= (3, 3):
+            with Pool(nworkers) as pool:
+                sampler = emcee.EnsembleSampler(
+                    n_walkers, n_dim, log_posterior_transit,
+                    args=(init_params, init_m, stimes, smags, serrs, priorbounds),
+                    pool=pool,
+                    backend=backend
+                )
+                sampler.run_mcmc(starting_positions, n_mcmc_steps,
+                                 progress=mcmcprogressbar)
+
+        elif sys.version_info < (3, 3):
+            # multiprocessing was upgraded to be a context manager in py3.3
+            # https://stackoverflow.com/questions/25968518/python-multiprocessing-lib-error-attributeerror-exit
+            from contextlib import contextmanager
+
+            @contextmanager
+            def terminating(process):
+                try:
+                    yield process
+                finally:
+                    process.terminate()
+
+            with terminating(Pool(nworkers)) as pool:
+                sampler = emcee.EnsembleSampler(
+                    n_walkers, n_dim, log_posterior_transit,
+                    args=(init_params, init_m, stimes, smags, serrs, priorbounds),
+                    pool=pool,
+                    backend=backend
+                )
+                sampler.run_mcmc(starting_positions, n_mcmc_steps,
+                                 progress=mcmcprogressbar)
 
         if verbose:
             LOGINFO(


### PR DESCRIPTION
requires a "terminating" context manager, since this was a new feature
`multiprocessing` added in 3.3