### PR TITLE
Use correct period with periodepsilon in zgls.py

### DIFF
--- a/astrobase/periodbase/zgls.py
+++ b/astrobase/periodbase/zgls.py
@@ -588,7 +588,7 @@ def pgen_lsp(
             # periodepsilon to make sure we jump to an entire different peak
             # in the periodogram
             if (perioddiff > (periodepsilon*prevperiod) and
-                all(x > (periodepsilon*prevperiod) for x in bestperiodsdiff)):
+                all(x > (periodepsilon*period) for x in bestperiodsdiff)):
                 nbestperiods.append(period)
                 nbestlspvals.append(lspval)
                 peakcount = peakcount + 1


### PR DESCRIPTION
Noticed this, maybe I'm wrong but it made more sense for me that the bestperiodsdiff values be compared with the current period, not the previous period.  I haven't checked whether a similar algorithm is used in the other period search algorithms but if so and this change is valid, those should be changed too.