### PR TITLE
periodbase: add transit least squares

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,9 +133,12 @@ Python 3.6: [![Python 3.6](https://ci.wbhatti.org/buildStatus/icon?job=astrobase
   **[periodbase.smav](https://astrobase.readthedocs.io/en/latest/astrobase.periodbase.smav.html)**), the BLS algorithm from
   Kovacs et al. ([2002](http://adsabs.harvard.edu/abs/2002A%26A...391..369K);
   **[periodbase.kbls](https://astrobase.readthedocs.io/en/latest/astrobase.periodbase.kbls.html)**
-  and **[periodbase.abls](https://astrobase.readthedocs.io/en/latest/astrobase.periodbase.abls.html)**), and the ACF
-  period-finding algorithm from McQuillan et
-  al. ([2013a](http://adsabs.harvard.edu/abs/2013MNRAS.432.1203M),
+  and **[periodbase.abls](https://astrobase.readthedocs.io/en/latest/astrobase.periodbase.abls.html)**), 
+  the similar TLS algorithm from Hippke & Heller
+  ([2019](https://ui.adsabs.harvard.edu/abs/2019A%26A...623A..39H/abstract);
+  **[periodbase.tls](https://astrobase.readthedocs.io/en/latest/astrobase.periodbase.tls.html)**),
+  and the ACF period-finding algorithm from McQuillan et al.
+  ([2013a](http://adsabs.harvard.edu/abs/2013MNRAS.432.1203M),
   [2014](http://adsabs.harvard.edu/abs/2014ApJS..211...24M);
   **[periodbase.macf](https://astrobase.readthedocs.io/en/latest/astrobase.periodbase.macf.html)**).
 

--- a/astrobase/periodbase/__init__.py
+++ b/astrobase/periodbase/__init__.py
@@ -22,6 +22,9 @@
 - :py:mod:`astrobase.periodbase.abls`: -> Kovacs et al. (2002) BLS using
   Astropy's implementation.
 
+- :py:mod:`astrobase.periodbase.tls`: Hippke & Heller (2019) BLS, but with a
+  nicer template.
+
 - :py:mod:`astrobase.periodbase.macf`: -> McQuillan et al. (2013a, 2014) ACF
   period search.
 
@@ -199,6 +202,7 @@ from .saov import aov_periodfind
 from .smav import aovhm_periodfind
 from .macf import macf_period_find
 from .kbls import bls_serial_pfind, bls_parallel_pfind
+from .tls import tls_parallel_pfind
 
 # used to figure out which function to run for bootstrap resampling
 LSPMETHODS = {
@@ -208,7 +212,8 @@ LSPMETHODS = {
     'mav':aovhm_periodfind,
     'pdm':stellingwerf_pdm,
     'acf':macf_period_find,
-    'win':specwindow_lsp
+    'win':specwindow_lsp,
+    'tls':tls_parallel_pfind
 }
 
 

--- a/astrobase/periodbase/__init__.py
+++ b/astrobase/periodbase/__init__.py
@@ -202,7 +202,11 @@ from .saov import aov_periodfind
 from .smav import aovhm_periodfind
 from .macf import macf_period_find
 from .kbls import bls_serial_pfind, bls_parallel_pfind
-from .tls import tls_parallel_pfind
+try:
+    from .tls import tls_parallel_pfind
+    HAVE_TLS=True
+except:
+    HAVE_TLS=False
 
 # used to figure out which function to run for bootstrap resampling
 LSPMETHODS = {
@@ -212,9 +216,10 @@ LSPMETHODS = {
     'mav':aovhm_periodfind,
     'pdm':stellingwerf_pdm,
     'acf':macf_period_find,
-    'win':specwindow_lsp,
-    'tls':tls_parallel_pfind
+    'win':specwindow_lsp
 }
+if HAVE_TLS:
+    LSPMETHODS['tls'] = tls_parallel_pfind
 
 
 # check if we have the astropy implementation of BLS available

--- a/astrobase/periodbase/tls.py
+++ b/astrobase/periodbase/tls.py
@@ -288,7 +288,7 @@ def tls_parallel_pfind(times, mags, errs,
     model = transitleastsquares(stimes, smags, serrs)
     tlsresult = model.power(use_threads=nworkers, show_progress_bar=False,
                             R_star_min=tls_R_star_min,
-                            R_star_max=tls_R_star_min,
+                            R_star_max=tls_R_star_max,
                             M_star_min=tls_M_star_min,
                             M_star_max=tls_M_star_max,
                             period_min=startp, period_max=endp,

--- a/astrobase/periodbase/tls.py
+++ b/astrobase/periodbase/tls.py
@@ -1,0 +1,380 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# tls.py - Luke Bouma (luke@astro.princeton.edu) - Apr 2019
+
+"""
+Contains the Hippke & Heller (2019) transit-least-squared period-search
+algorithm implementation for periodbase. This depends on the external package
+written by Hippke & Heller, https://github.com/hippke/tls.
+"""
+
+#############
+## LOGGING ##
+#############
+
+import logging
+from astrobase import log_sub, log_fmt, log_date_fmt
+
+DEBUG = False
+if DEBUG:
+    level = logging.DEBUG
+else:
+    level = logging.INFO
+LOGGER = logging.getLogger(__name__)
+logging.basicConfig(
+    level=level,
+    style=log_sub,
+    format=log_fmt,
+    datefmt=log_date_fmt,
+)
+
+LOGDEBUG = LOGGER.debug
+LOGINFO = LOGGER.info
+LOGWARNING = LOGGER.warning
+LOGERROR = LOGGER.error
+LOGEXCEPTION = LOGGER.exception
+
+
+#############
+## IMPORTS ##
+#############
+
+import numpy as np
+
+from multiprocessing import Pool, cpu_count
+
+from math import fmod
+
+from numpy import (
+    nan as npnan, arange as nparange, array as nparray,
+    isfinite as npisfinite, argmax as npargmax, linspace as nplinspace,
+    ceil as npceil, argsort as npargsort, concatenate as npconcatenate
+)
+
+from astropy import units as u
+
+try:
+    from transitleastsquares import transitleastsquares
+except:
+    errmsg = (
+        'tried importing transitleastsquares and failed.\n'
+        'are you sure you have installed it correctly?\n'
+        'see https://transitleastsquares.readthedocs.io/en/latest/Installation.html'
+    )
+    raise AssertionError(errmsg)
+
+
+###################
+## LOCAL IMPORTS ##
+###################
+
+from ..lcmath import sigclip_magseries
+
+
+############
+## CONFIG ##
+############
+
+NCPUS = cpu_count()
+
+
+#######################
+## UTILITY FUNCTIONS ##
+#######################
+
+def tls_parallel_pfind(times, mags, errs=None,
+                       magsarefluxes=None,
+                       startp=0.1,  # search from 0.1 d to...
+                       endp=None,   # determine automatically from times
+                       tlsoversample=5,
+                       tlsmintransits=3,
+                       periodepsilon=0.1,
+                       nbestpeaks=5,
+                       sigclip=10.0,
+                       verbose=True,
+                       nworkers=None):
+    """
+    Wrapper to Hippke & Heller (2019)'s "transit least squares", which is BLS,
+    but with a slightly better template (and niceties in the implementation).
+
+    A few comments:
+
+    * The time series must be in units of days.
+
+    * The frequency sampling Hippke & Heller (2019) advocate for is cubic in
+    frequencies, instead of linear. Ofir (2014) found that the
+    linear-in-frequency sampling (which is correct for sinusoidal signal
+    detection) isn't optimal for a Keplerian box signal. He gave an equation
+    for "optimal" sampling. `tlsoversample` is the factor by which to
+    oversample over that. The grid can be imported independently via
+
+        `from transitleastsquares import period_grid`
+
+    The spacing equations are given here:
+    https://transitleastsquares.readthedocs.io/en/latest/Python%20interface.html#period-grid
+
+    * The boundaries of the period search are by default 0.1 day to 99% the
+    baseline of times.
+
+    Parameters
+    ----------
+
+    times,mags,errs : np.array
+        The magnitude/flux time-series to search for transits.
+
+    magsarefluxes : bool
+        As-implemented, must be true.
+
+    startp,endp : float
+        The minimum and maximum periods to consider for the transit search.
+
+    tlsoversample : int
+        Factor by which to oversample the frequency grid.
+
+    tlsmintransits : int
+        Sets the `min_n_transits` kwarg for the `BoxLeastSquares.autoperiod()`
+        function.
+
+    periodepsilon : float
+        The fractional difference between successive values of 'best' periods
+        when sorting by periodogram power to consider them as separate periods
+        (as opposed to part of the same periodogram peak). This is used to avoid
+        broad peaks in the periodogram and make sure the 'best' periods returned
+        are all actually independent.
+
+    nbestpeaks : int
+        The number of 'best' peaks to return from the periodogram results,
+        starting from the global maximum of the periodogram peak values.
+
+    sigclip : float or int or sequence of two floats/ints or None
+        If a single float or int, a symmetric sigma-clip will be performed using
+        the number provided as the sigma-multiplier to cut out from the input
+        time-series.
+
+        If a list of two ints/floats is provided, the function will perform an
+        'asymmetric' sigma-clip. The first element in this list is the sigma
+        value to use for fainter flux/mag values; the second element in this
+        list is the sigma value to use for brighter flux/mag values. For
+        example, `sigclip=[10., 3.]`, will sigclip out greater than 10-sigma
+        dimmings and greater than 3-sigma brightenings. Here the meaning of
+        "dimming" and "brightening" is set by *physics* (not the magnitude
+        system), which is why the `magsarefluxes` kwarg must be correctly set.
+
+        If `sigclip` is None, no sigma-clipping will be performed, and the
+        time-series (with non-finite elems removed) will be passed through to
+        the output.
+
+    verbose : bool
+        Kept for consistency with `periodbase` functions.
+
+    nworkers : int or None
+        The number of parallel workers to launch for period-search. If None,
+        nworkers = NCPUS.
+
+    Returns
+    -------
+
+    dict
+        This function returns a dict, referred to as an `lspinfo` dict in other
+        astrobase functions that operate on periodogram results. The format is
+        similar to the other astrobase period-finders -- it contains the
+        nbestpeaks, which is the most important thing. (But isn't entirely
+        standardized.)
+
+        Crucially, it also contains "tlsresult", which is a dictionary with
+        transitleastsquares spectra (used to get the SDE as defined in the TLS
+        paper), statistics, transit period, mid-time, duration, depth, SNR, and
+        the "odd_even_mismatch" statistic. The full key list is:
+
+            dict_keys(['SDE', 'SDE_raw', 'chi2_min', 'chi2red_min', 'period',
+            'period_uncertainty', 'T0', 'duration', 'depth', 'depth_mean',
+            'depth_mean_even', 'depth_mean_odd', 'transit_depths',
+            'transit_depths_uncertainties', 'rp_rs', 'snr', 'snr_per_transit',
+            'snr_pink_per_transit', 'odd_even_mismatch', 'transit_times',
+            'per_transit_count', 'transit_count', 'distinct_transit_count',
+            'empty_transit_count', 'FAP', 'in_transit_count', 'after_transit_count',
+            'before_transit_count', 'periods', 'power', 'power_raw', 'SR', 'chi2',
+            'chi2red', 'model_lightcurve_time', 'model_lightcurve_model',
+            'model_folded_phase', 'folded_y', 'folded_dy', 'folded_phase',
+            'model_folded_model'])
+
+        The descriptions are here:
+        https://transitleastsquares.readthedocs.io/en/latest/Python%20interface.html#return-values
+
+        The remaining resultdict is:
+
+            resultdict = {
+                'tlsresult':tlsresult,
+                'bestperiod': the best period value in the periodogram,
+                'bestlspval': the periodogram peak associated with the best period,
+                'nbestpeaks': the input value of nbestpeaks,
+                'nbestlspvals': nbestpeaks-size list of best period peak values,
+                'nbestperiods': nbestpeaks-size list of best periods,
+                'lspvals': the full array of periodogram powers,
+                'periods': the full array of periods considered,
+                'tlsresult': Astropy tls result object (BoxLeastSquaresResult),
+                'tlsmodel': Astropy tls BoxLeastSquares object used for work,
+                'method':'tls' -> the name of the period-finder method,
+                'kwargs':{ dict of all of the input kwargs for record-keeping}
+            }
+    """
+
+    if not magsarefluxes:
+        errmsg = ('IDK if transitleastsquares supports magnitudes. '
+                  'many of its utilities would probably break.')
+        raise NotImplementedError(errmsg)
+
+    if nworkers is None:
+        nworkers = NCPUS
+
+    # get rid of nans first and sigclip
+    stimes, smags, serrs = sigclip_magseries(times, mags, errs,
+                                             magsarefluxes=magsarefluxes,
+                                             sigclip=sigclip)
+
+    # make sure there are enough points to calculate a spectrum
+    if not (len(stimes) > 9 and len(smags) > 9 and len(serrs) > 9):
+        LOGERROR('no good detections for these times and mags, skipping...')
+        resultdict = {
+            'tlsresult':npnan,
+            'bestperiod':npnan,
+            'bestlspval':npnan,
+            'nbestpeaks':nbestpeaks,
+            'nbestinds':None,
+            'nbestlspvals':None,
+            'nbestperiods':None,
+            'lspvals':None,
+            'periods':None,
+            'method':'tls',
+            'kwargs':{'startp':startp,
+                      'endp':endp,
+                      'tlsoversample':tlsoversample,
+                      'tlsntransits':tlsmintransits,
+                      'periodepsilon':periodepsilon,
+                      'nbestpeaks':nbestpeaks,
+                      'sigclip':sigclip,
+                      'magsarefluxes':magsarefluxes}
+        }
+        return resultdict
+
+    if endp is None:
+        # out to 99% of the baseline. (for two transits).
+        endp = 0.99*(np.nanmax(stimes) - np.nanmin(stimes))
+
+    if isinstance(errs,np.ndarray):
+        model = transitleastsquares(stimes, smags, serrs)
+    else:
+        model = transitleastsquares(stimes, smags)
+
+    # run periodogram
+    tlsresult = model.power(use_threads=nworkers, show_progress_bar=False,
+                            R_star_min=0.13, R_star_max=3.5, M_star_min=0.1,
+                            M_star_max=2.0, period_min=startp, period_max=endp,
+                            n_transits_min=tlsmintransits,
+                            transit_template='default',
+                            oversampling_factor=tlsoversample)
+
+    # get the peak values
+    lsp = nparray(tlsresult.power)
+    periods = nparray(tlsresult.periods)
+
+    # find the nbestpeaks for the periodogram: 1. sort the lsp array by highest
+    # value first 2. go down the values until we find five values that are
+    # separated by at least periodepsilon in period make sure to get only the
+    # finite peaks in the periodogram this is needed because tls may produce
+    # infs for some peaks
+    finitepeakind = npisfinite(lsp)
+    finlsp = lsp[finitepeakind]
+    finperiods = periods[finitepeakind]
+
+    # make sure that finlsp has finite values before we work on it
+    try:
+
+        bestperiodind = npargmax(finlsp)
+
+    except ValueError:
+
+        LOGERROR('no finite periodogram values '
+                 'for this mag series, skipping...')
+        resultdict = {
+            'tlsresult':npnan,
+            'bestperiod':npnan,
+            'bestlspval':npnan,
+            'nbestpeaks':nbestpeaks,
+            'nbestinds':None,
+            'nbestlspvals':None,
+            'nbestperiods':None,
+            'lspvals':None,
+            'periods':None,
+            'method':'tls',
+            'kwargs':{'startp':startp,
+                      'endp':endp,
+                      'tlsoversample':tlsoversample,
+                      'tlsntransits':tlsmintransits,
+                      'periodepsilon':periodepsilon,
+                      'nbestpeaks':nbestpeaks,
+                      'sigclip':sigclip,
+                      'magsarefluxes':magsarefluxes}
+        }
+        return resultdict
+
+    sortedlspind = npargsort(finlsp)[::-1]
+    sortedlspperiods = finperiods[sortedlspind]
+    sortedlspvals = finlsp[sortedlspind]
+
+    # now get the nbestpeaks
+    nbestperiods, nbestlspvals, nbestinds, peakcount = (
+        [finperiods[bestperiodind]],
+        [finlsp[bestperiodind]],
+        [bestperiodind],
+        1
+    )
+    prevperiod = sortedlspperiods[0]
+
+    # find the best nbestpeaks in the lsp and their periods
+    for period, lspval, ind in zip(sortedlspperiods,
+                                   sortedlspvals,
+                                   sortedlspind):
+
+        if peakcount == nbestpeaks:
+            break
+        perioddiff = abs(period - prevperiod)
+        bestperiodsdiff = [abs(period - x) for x in nbestperiods]
+
+        # this ensures that this period is different from the last
+        # period and from all the other existing best periods by
+        # periodepsilon to make sure we jump to an entire different
+        # peak in the periodogram
+        if (perioddiff > (periodepsilon*prevperiod) and
+            all(x > (periodepsilon*period)
+                for x in bestperiodsdiff)):
+            nbestperiods.append(period)
+            nbestlspvals.append(lspval)
+            nbestinds.append(ind)
+            peakcount = peakcount + 1
+
+        prevperiod = period
+
+    # generate the return dict
+    resultdict = {
+        'tlsresult':tlsresult,
+        'bestperiod':finperiods[bestperiodind],
+        'bestlspval':finlsp[bestperiodind],
+        'nbestpeaks':nbestpeaks,
+        'nbestinds':nbestinds,
+        'nbestlspvals':nbestlspvals,
+        'nbestperiods':nbestperiods,
+        'lspvals':lsp,
+        'periods':periods,
+        'method':'tls',
+        'kwargs':{'startp':startp,
+                  'endp':endp,
+                  'tlsoversample':tlsoversample,
+                  'tlsntransits':tlsmintransits,
+                  'periodepsilon':periodepsilon,
+                  'nbestpeaks':nbestpeaks,
+                  'sigclip':sigclip,
+                  'magsarefluxes':magsarefluxes}
+    }
+
+    return resultdict

--- a/astrobase/plotbase.py
+++ b/astrobase/plotbase.py
@@ -1270,7 +1270,8 @@ PLOTYLABELS = {'gls':'Generalized Lomb-Scargle normalized power',
                'bls':'Box Least-squared Search SR',
                'acf':'Autocorrelation Function',
                'win':'Lomb-Scargle normalized power',
-               'ext':'External period-finder power'}
+               'ext':'External period-finder power',
+               'tls':'Transit Least-Squares SDE'}
 
 METHODLABELS = {'gls':'Generalized Lomb-Scargle periodogram',
                 'pdm':'Stellingwerf phase-dispersion minimization',
@@ -1279,7 +1280,8 @@ METHODLABELS = {'gls':'Generalized Lomb-Scargle periodogram',
                 'bls':'Box Least-squared Search',
                 'acf':'McQuillan+ ACF Period Search',
                 'win':'Timeseries Sampling Lomb-Scargle periodogram',
-                'ext':'External period-finder periodogram'}
+                'ext':'External period-finder periodogram',
+                'tls':'Transit Least-Squares periodogram'}
 
 METHODSHORTLABELS = {'gls':'Generalized L-S',
                      'pdm':'Stellingwerf PDM',
@@ -1288,7 +1290,8 @@ METHODSHORTLABELS = {'gls':'Generalized L-S',
                      'acf':'McQuillan+ ACF',
                      'bls':'BLS',
                      'win':'Sampling L-S',
-                     'ext':'External period-finder'}
+                     'ext':'External period-finder',
+                     'tls':'TLS'}
 
 
 def plot_periodbase_lsp(lspinfo, outfile=None, plotdpi=100):

--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,7 @@ EXTRAS_REQUIRE = {
         'h5py',
         'batman-package',
         'corner',
+        'transitleastsquares',
         'paramiko',
         'boto3',
         'awscli',
@@ -77,6 +78,10 @@ EXTRAS_REQUIRE = {
         'h5py',
         'batman-package',
         'corner',
+    ],
+    # for periodbase.tls
+    'tls':[
+        'transitleastsquares'
     ],
     # for lcproc_aws and awsutils
     'aws':[


### PR DESCRIPTION
This commit adds a wrapper to Hippke and Heller's transit least squares
package (2019; arxiv.org/abs/1901.02015).

A few comments:

* `test_tls_parallel()` passes

* the `resultdict` returned by `tls_parallel_pfind` doesn't exactly
match the astrobase standard, because of the details of the
transitleastsquares inputs/outputs.  In particular, this wrapper
relinquishes control of the frequency grid, in favor of the one Hippke &
Heller implemented.

* a review before merging would be appreciated!