### PR TITLE
add services.convert_identifiers, + minor improvements

### DIFF
--- a/astrobase/checkplot/pkl.py
+++ b/astrobase/checkplot/pkl.py
@@ -67,6 +67,7 @@ import os
 import os.path
 import gzip
 import sys
+import re
 import hashlib
 
 try:
@@ -76,7 +77,19 @@ except Exception as e:
 
 # we're going to plot using Agg only
 import matplotlib
-MPLVERSION = tuple([int(x) for x in matplotlib.__version__.split('.')])
+
+mpl_regex = re.findall('rc[0-9]', matplotlib.__version__)
+
+if len(mpl_regex) == 1:
+    # some matplotlib versions are e.g., "3.1.0rc1", which we resolve to
+    # "(3,1,0)".
+    MPLVERSION = tuple([
+        int(x) for x in
+        matplotlib.__version__.replace(mpl_regex[0],'').split('.')]
+    )
+else:
+    MPLVERSION = tuple([int(x) for x in matplotlib.__version__.split('.')])
+
 matplotlib.use('Agg')
 
 # import this to check if stimes, smags, serrs are Column objects

--- a/astrobase/checkplot/pkl_utils.py
+++ b/astrobase/checkplot/pkl_utils.py
@@ -44,6 +44,7 @@ import os.path
 import gzip
 import base64
 import json
+import re
 
 try:
     import cPickle as pickle
@@ -57,7 +58,19 @@ from numpy import min as npmin, max as npmax, abs as npabs
 
 # we're going to plot using Agg only
 import matplotlib
-MPLVERSION = tuple([int(x) for x in matplotlib.__version__.split('.')])
+
+mpl_regex = re.findall('rc[0-9]', matplotlib.__version__)
+
+if len(mpl_regex) == 1:
+    # some matplotlib versions are e.g., "3.1.0rc1", which we resolve to
+    # "(3,1,0)".
+    MPLVERSION = tuple([
+        int(x) for x in
+        matplotlib.__version__.replace(mpl_regex[0],'').split('.')]
+    )
+else:
+    MPLVERSION = tuple([int(x) for x in matplotlib.__version__.split('.')])
+
 matplotlib.use('Agg')
 
 import matplotlib.pyplot as plt

--- a/astrobase/checkplot/png.py
+++ b/astrobase/checkplot/png.py
@@ -493,6 +493,7 @@ def _make_phased_magseries_plot(axes,
                                 phasebinms=4.0,
                                 xticksize=None,
                                 yticksize=None,
+                                titlefontsize='medium',
                                 makegrid=True,
                                 lowerleftstr=None,
                                 lowerleftfontsize=None):
@@ -521,12 +522,14 @@ def _make_phased_magseries_plot(axes,
         The epoch to use for this phased light curve plot tile. If this is a
         float, will use the provided value directly. If this is 'min', will
         automatically figure out the time-of-minimum of the phased light
-        curve. If this is None, will use the mimimum value of `stimes` as the
-        epoch of the phased light curve plot. If this is a list of lists, will
-        use the provided value of `lspmethodind` to look up the current
-        period-finder method and the provided value of `periodind` to look up
-        the epoch associated with that method and the current period. This is
-        mostly only useful when `twolspmode` is True.
+        curve. If it is "percentile_N", for N an integer, it will be phased to
+        that percentile of the flux (less noisy than the minimum). If this is
+        None, will use the mimimum value of `stimes` as the epoch of the phased
+        light curve plot. If this is a list of lists, will use the provided
+        value of `lspmethodind` to look up the current period-finder method and
+        the provided value of `periodind` to look up the epoch associated with
+        that method and the current period. This is mostly only useful when
+        `twolspmode` is True.
 
     phasewrap : bool
         If this is True, the phased time-series will be wrapped around
@@ -585,6 +588,9 @@ def _make_phased_magseries_plot(axes,
 
     xticksize,yticksize : int or None
         Fontsize for x and y ticklabels
+
+    titlefontsize: str or float
+        Fontsize for the panel title. Default: 'medium'
 
     lowerleftstr : str or None
         Optional text to overplot in lower left of plot
@@ -646,6 +652,23 @@ def _make_phased_magseries_plot(axes,
                          'the phase-folded LC')
 
                 plotvarepoch = npmin(stimes)
+
+
+    elif isinstance(varepoch, str) and 'percentile' in varepoch:
+
+        # assume format of "percentile_N"
+        percentile_int = int(varepoch.split('_')[-1])
+
+        nearest_index = (
+            abs(
+                smags
+                -
+                nppercentile(smags, percentile_int, interpolation='nearest')
+            ).argmin()
+        )
+
+        plotvarepoch = stimes[nearest_index]
+
 
     elif isinstance(varepoch, list):
 
@@ -788,7 +811,7 @@ def _make_phased_magseries_plot(axes,
             plotvarepoch
         )
 
-    axes.set_title(plottitle)
+    axes.set_title(plottitle, fontsize=titlefontsize)
 
     if isinstance(lowerleftstr, str):
         axes.text(

--- a/astrobase/checkplot/png.py
+++ b/astrobase/checkplot/png.py
@@ -64,6 +64,7 @@ LOGEXCEPTION = LOGGER.exception
 
 import os
 import os.path
+import re
 import gzip
 
 try:
@@ -72,11 +73,24 @@ except Exception as e:
     import pickle
 
 from numpy import isfinite as npisfinite, \
-    min as npmin, max as npmax, abs as npabs, ravel as npravel, nan as npnan
+    min as npmin, max as npmax, abs as npabs, ravel as npravel, nan as npnan, \
+    percentile as nppercentile
 
 # we're going to plot using Agg only
 import matplotlib
-MPLVERSION = tuple([int(x) for x in matplotlib.__version__.split('.')])
+
+mpl_regex = re.findall('rc[0-9]', matplotlib.__version__)
+
+if len(mpl_regex) == 1:
+    # some matplotlib versions are e.g., "3.1.0rc1", which we resolve to
+    # "(3,1,0)".
+    MPLVERSION = tuple([
+        int(x) for x in
+        matplotlib.__version__.replace(mpl_regex[0],'').split('.')]
+    )
+else:
+    MPLVERSION = tuple([int(x) for x in matplotlib.__version__.split('.')])
+
 matplotlib.use('Agg')
 
 import matplotlib.pyplot as plt

--- a/astrobase/services/convert_identifiers.py
+++ b/astrobase/services/convert_identifiers.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# convert_identifiers.py - Luke Bouma (bouma.luke@gmail.com) - Oct 2019
+# License: MIT - see the LICENSE file for the full text.
+
+'''
+Easy conversion between survey identifiers. Works best on bright and/or famous
+objects, particularly when SIMBAD is involved.
+
+given simbad name, attempt to get DR2 source_id
+
+given DR2 source_id, attempt to get TIC ID
+
+given simbad name, get TIC ID
+
+given TIC ID, get simbad name
+'''
+
+#############
+## LOGGING ##
+#############
+
+import logging
+from astrobase import log_sub, log_fmt, log_date_fmt
+
+DEBUG = False
+if DEBUG:
+    level = logging.DEBUG
+else:
+    level = logging.INFO
+LOGGER = logging.getLogger(__name__)
+logging.basicConfig(
+    level=level,
+    style=log_sub,
+    format=log_fmt,
+    datefmt=log_date_fmt,
+)
+
+LOGDEBUG = LOGGER.debug
+LOGINFO = LOGGER.info
+LOGWARNING = LOGGER.warning
+LOGERROR = LOGGER.error
+LOGEXCEPTION = LOGGER.exception
+
+
+#############
+## IMPORTS ##
+#############
+
+import pandas as pd, numpy as np
+from astropy.coordinates import SkyCoord
+from astropy import units as u, constants as const
+
+from astrobase.services.simbad import tap_query as simbad_tap_query
+from astrobase.services.gaia import objectid_search as gaia_objectid_search
+
+
+try:
+    from astroquery.mast import Catalogs
+    from astroquery.simbad import Simbad
+    astroquery_dependencies = True
+except ImportError:
+    astroquery_dependencies = False
+
+
+def simbad2gaiadrtwo(simbad_name,
+                     simbad_mirror='simbad', returnformat='csv',
+                     forcefetch=False, cachedir='~/.astrobase/simbad-cache',
+                     verbose=True, timeout=10.0, refresh=2.0, maxtimeout=90.0,
+                     maxtries=1, complete_query_later=True):
+    """
+    Convenience function that, given a SIMBAD object name, returns string of
+    the Gaia-DR2 identifier.
+
+    simbad_name: string as you would search on SIMBAD.
+    """
+
+    assert isinstance(simbad_name, str)
+
+    # TAP table list is here:
+    # http://simbad.u-strasbg.fr/simbad/tap/tapsearch.html
+    query = (
+    "SELECT basic.OID, basic.RA, basic.DEC, ident.id, ident.oidref, ids.ids "
+    "FROM basic "
+    "LEFT OUTER JOIN ident ON ident.oidref = basic.oid "
+    "LEFT OUTER JOIN ids ON ids.oidref = ident.oidref "
+    "WHERE ident.id = '{simbad_name}'; "
+    )
+
+    formatted_query = query.format(simbad_name=simbad_name)
+
+    # astroquery.simbad would have been fine here too. Sometimes pure astrobase
+    # solutions are nice though ;-).
+    r =  simbad_tap_query(formatted_query, simbad_mirror=simbad_mirror,
+                          returnformat=returnformat, forcefetch=forcefetch,
+                          cachedir=cachedir, verbose=verbose, timeout=timeout,
+                          refresh=refresh, maxtimeout=maxtimeout,
+                          maxtries=maxtries,
+                          complete_query_later=complete_query_later)
+
+    df = pd.read_csv(r['result'])
+
+    if len(df) != 1:
+        errmsg = (
+            'Expected 1 result from name {}; got {} results.'.
+            format(simbad_name, len(df))
+        )
+        raise ValueError(errmsg)
+
+    if 'Gaia DR2' not in df['ids'].iloc[0]:
+        errmsg = (
+            'Failed to retrieve Gaia DR2 identifier for {}'.
+            format(simbad_name)
+        )
+        raise NameError(errmsg)
+
+    # simbad returns a "|"-separated list of cross-matched names
+    names = df['ids'].iloc[0].split('|')
+
+    gaia_name = [n for n in names if 'Gaia DR2' in n]
+
+    gaia_id = gaia_name[0].split(' ')[-1]
+
+    return gaia_id
+
+
+def gaiadrtwo2tic(source_id, returnformat='csv', gaia_mirror='gaia',
+                  forcefetch=False, cachedir='~/.astrobase/simbad-cache',
+                  verbose=True, timeout=10.0, refresh=2.0, maxtimeout=90.0,
+                  maxtries=1, complete_query_later=True):
+    """
+    First, gets RA/dec from Gaia DR2, given source_id. Then searches TICv8
+    spatially, and returns matches with the correct DR2 source_id.
+
+    Parameters
+    ----------
+    source_id: Gaia DR2 source identifier.
+
+    Remainder are described in `astrobase.services.gaia.objectid_search`
+    """
+
+    if not astroquery_dependencies:
+        raise ImportError(
+            'This function depends on astroquery.'
+        )
+
+    r = gaia_objectid_search(source_id, gaia_mirror=gaia_mirror,
+                             returnformat=returnformat, forcefetch=forcefetch,
+                             cachedir=cachedir, verbose=verbose,
+                             timeout=timeout, refresh=refresh,
+                             maxtimeout=maxtimeout, maxtries=maxtries,
+                             complete_query_later=complete_query_later)
+
+    try:
+        df = pd.read_csv(r['result'])
+    except pd.errors.EmptyDataError:
+        errmsg = (
+            'Expected 1 Gaia result from source_id {}; got no results.'.
+            format(source_id)
+        )
+        raise pd.errors.EmptyDataError(errmsg)
+
+    ra, dec = df['ra'].iloc[0], df['dec'].iloc[0]
+
+    coord = SkyCoord(ra=ra, dec=dec, unit=(u.degree, u.degree), frame='icrs')
+    radius = 0.5*u.arcminute
+    try:
+        stars = Catalogs.query_region(
+            "{} {}".format(float(coord.ra.value), float(coord.dec.value)),
+            catalog="TIC", radius=radius
+        )
+    except requests.exceptions.ConnectionError:
+        LOGWARNING('WRN! TIC query failed. trying again...')
+        time.sleep(60)
+        stars = Catalogs.query_region(
+            "{} {}".format(float(coord.ra.value), float(coord.dec.value)),
+            catalog="TIC", radius=radius
+        )
+
+    sel = ~stars['GAIA'].mask
+    selstars = stars[sel]
+
+    if len(selstars)>=1:
+
+        # TICv8 was based on Gaia DR2: enforce that the TICv8 TICID match that's
+        # returned has a Gaia source_id listed in the TIC that is the same as
+        # the source_id passed to this function.
+        if np.any(
+            np.in1d(np.array(selstars['GAIA']).astype(np.int64),
+                    np.array(np.int64(source_id)))
+        ):
+
+            ind = (
+                int(np.where(
+                        np.in1d(
+                            np.array(selstars['GAIA']).astype(np.int64),
+                            np.array(np.int64(source_id))))[0]
+                )
+            )
+
+            mrow = selstars[ind]
+
+    if len(mrow) == 0:
+        errmsg = (
+            'Failed to retrieve TIC identifier for Gaia DR2 {}'.
+            format(source_id)
+        )
+        raise NameError(errmsg)
+
+    ticid = mrow['ID']
+    return ticid
+
+
+def simbad2tic(simbad_name):
+
+    source_id = simbad2gaiadrtwo(simbad_name)
+
+    return gaiadrtwo2tic(source_id)

--- a/astrobase/services/simbad.py
+++ b/astrobase/services/simbad.py
@@ -54,6 +54,7 @@ import time
 import pickle
 
 import numpy as np
+import pandas as pd
 
 import random
 
@@ -818,16 +819,9 @@ def tap_query(querystr,
 
         # try to open the cached file to make sure it's OK
         try:
-            infd = gzip.open(cachefname,'rb')
-            simbad_objectnames = np.genfromtxt(
-                infd,
-                names=True,
-                delimiter=',',
-                dtype='U20,f8,f8,U20,U20,U20,i8,U600,f8',
-                usecols=(0,1,2,3,4,5,6,7,8),
-                comments='?',  # object names can have '#' in them
-            )
-            infd.close()
+
+            df = pd.read_csv(cachefname)
+            assert len(df) >= 1
 
         except Exception as e:
 

--- a/tests/test_convert_identifiers.py
+++ b/tests/test_convert_identifiers.py
@@ -1,0 +1,71 @@
+"""
+test_convert_identifiers.py - Luke Bouma (luke@astro.princeton.edu) - Oct 2019
+License: MIT - see the LICENSE file for details.
+
+Test easy conversion between survey identifiers.
+"""
+
+###########
+# imports #
+###########
+from astrobase.services.convert_identifiers import (
+    simbad2gaiadrtwo,
+    gaiadrtwo2tic,
+    simbad2tic
+)
+
+import unittest
+
+##########
+# config #
+##########
+
+class BadQueryTestCases(unittest.TestCase):
+    """
+    Class that enables requiring particular exceptions to be raised.
+    """
+
+    def bad_simbad2targetcatalog_test(self, bad_identifier, target_function):
+        """
+        bad_identifier (str): a valid SIMBAD identifier that doesn't have a
+        Gaia DR2 identifier
+
+        target_function (function): either of
+        `astrobase.service.convert_identifiers.simbad2gaiadrtwo` or
+        `astrobase.service.convert_identifiers.simbad2tic`
+        """
+
+        with self.assertRaises(NameError) as context:
+            target_function(bad_identifier)
+
+        self.assertTrue(
+            'Failed to retrieve Gaia DR2 identifier' in str(context.exception)
+        )
+
+
+####################
+# tests to execute #
+####################
+
+def test_simbad2gaiadrtwo():
+
+    assert simbad2gaiadrtwo('WASP-4') == '6535499658122055552'
+
+    #
+    # Orion Nebula is an open cluster; doesn't have Gaia DR2 identifier.
+    #
+    b = BadQueryTestCases()
+    b.bad_simbad2targetcatalog_test('M 42', simbad2gaiadrtwo)
+
+
+def test_gaiadrtwo2tic():
+
+    assert gaiadrtwo2tic('6535499658122055552') == '402026209'
+
+
+def test_simbad2tic():
+
+    assert simbad2tic('WASP-4') == '402026209'
+
+    b = BadQueryTestCases()
+    b.bad_simbad2targetcatalog_test('M 42', simbad2tic)


### PR DESCRIPTION
The main addition here is  `services.convert_identifiers`, which contains the functions:  `simbad2gaiadrtwo`, `gaiadrtwo2tic`, and `simbad2tic`.

Plz see the commit strings for further context.