### PR TITLE
phase_bin_magseries_with_errs: add weights option

### DIFF
--- a/astrobase/lcmath.py
+++ b/astrobase/lcmath.py
@@ -1377,7 +1377,7 @@ def phase_bin_magseries_with_errs(phases, mags, errs,
     finite_phases = phases[finiteind]
     finite_mags = mags[finiteind]
     finite_errs = errs[finiteind]
-    if len(weights) > 10:
+    if weights is not None and len(weights) > 10:
         finite_weights = weights[finiteind]
 
     nbins = int(np.ceil((np.nanmax(finite_phases) -

--- a/astrobase/lcmath.py
+++ b/astrobase/lcmath.py
@@ -1322,7 +1322,8 @@ def phase_bin_magseries(phases, mags,
 
 def phase_bin_magseries_with_errs(phases, mags, errs,
                                   binsize=0.005,
-                                  minbinelems=7):
+                                  minbinelems=7,
+                                  weights=None):
     '''Bins a phased magnitude/flux time-series using the bin size provided.
 
     Parameters
@@ -1371,6 +1372,8 @@ def phase_bin_magseries_with_errs(phases, mags, errs,
     finite_phases = phases[finiteind]
     finite_mags = mags[finiteind]
     finite_errs = errs[finiteind]
+    if len(weights) > 10:
+        finite_weights = weights[finiteind]
 
     nbins = int(np.ceil((np.nanmax(finite_phases) -
                          np.nanmin(finite_phases))/binsize) + 1)
@@ -1419,10 +1422,17 @@ def phase_bin_magseries_with_errs(phases, mags, errs,
     collected_binned_mags['binsize'] = binsize
 
     # median bin the magnitudes according to the calculated indices
-    collected_binned_mags['binnedmags'] = (
-        np.array([np.median(finite_mags[x])
-                  for x in binned_finite_phaseseries_indices])
-    )
+    if finite_weights is None:
+        collected_binned_mags['binnedmags'] = (
+            np.array([np.median(finite_mags[x])
+                      for x in binned_finite_phaseseries_indices])
+        )
+    else:
+        collected_binned_mags['binnedmags'] = (
+            np.array([np.average(finite_mags[x], weights=finite_weights[x])
+                      for x in binned_finite_phaseseries_indices])
+        )
+
     collected_binned_mags['binnederrs'] = (
         np.array([np.median(finite_errs[x])
                   for x in binned_finite_phaseseries_indices])

--- a/astrobase/lcmath.py
+++ b/astrobase/lcmath.py
@@ -1345,7 +1345,7 @@ def phase_bin_magseries_with_errs(phases, mags, errs,
     weights : np.array or None
         Optional weight vector to be applied during binning. If if is passed,
         `np.average` is used to bin, rather than `np.median`. A good choice
-        would be to pass weights=1/errs**2, to weight by the inverse variance.
+        would be to pass ``weights=1/errs**2``, to weight by the inverse variance.
 
     Returns
     -------

--- a/astrobase/lcmath.py
+++ b/astrobase/lcmath.py
@@ -1379,6 +1379,8 @@ def phase_bin_magseries_with_errs(phases, mags, errs,
     finite_errs = errs[finiteind]
     if weights is not None and len(weights) > 10:
         finite_weights = weights[finiteind]
+    else:
+        finite_weights = None
 
     nbins = int(np.ceil((np.nanmax(finite_phases) -
                          np.nanmin(finite_phases))/binsize) + 1)

--- a/astrobase/lcmath.py
+++ b/astrobase/lcmath.py
@@ -1342,6 +1342,11 @@ def phase_bin_magseries_with_errs(phases, mags, errs,
         The minimum number of elements required per bin to include it in the
         output.
 
+    weights : np.array or None
+        Optional weight vector to be applied during binning. If if is passed,
+        `np.average` is used to bin, rather than `np.median`. A good choice
+        would be to pass weights=1/errs**2, to weight by the inverse variance.
+
     Returns
     -------
 

--- a/astrobase/services/identifiers.py
+++ b/astrobase/services/identifiers.py
@@ -13,6 +13,8 @@ objects, particularly when SIMBAD is involved.
 
 ``simbad_to_tic()``: given simbad name, get TIC ID
 
+``tic_to_gaiadr2()``: given TIC ID, get GAIA DR2 source_id
+
 '''
 
 #############


### PR DESCRIPTION
Useful for whenver you have a flux/magnitude time series with points
that have different error bars (for instance, from different
instruments), and you want to bin them.

In these cases, take a weights vector, and use `np.average(...,
weights=...)` instead of the unchanged default median-averaging.