### PR TITLE
Adding the alltesslightcurves module

### DIFF
--- a/astrobase/services/alltesslightcurves.py
+++ b/astrobase/services/alltesslightcurves.py
@@ -1,0 +1,44 @@
+'''
+A tool for aquiring TESS light curves from a variety of pipelines.
+Wraps functions found in tesslightcurves.py
+
+'''
+
+#############
+## IMPORTS ##
+#############
+
+import astrobase.services.tesslightcurves as tlc
+
+methodDict = {
+    '2minSPOC': tlc.get_two_minute_spoc_lightcurves,
+    'eleanor': tlc.get_eleanor_lightcurves,
+    'CDIPS': tlc.get_hlsp_lightcurves,
+    'PATHOS': tlc.get_hlsp_lightcurves,
+    'TASOC': tlc.get_hlsp_lightcurves
+}
+
+##########
+## WORK ##
+##########
+
+def get_all_tess_lightcurves(tic_id, 
+        pipelines=('CDIPS', 'PATHOS', 'TASOC', '2minSPOC', 'eleanor'), 
+        download_dir=None):
+    """
+    pipeline (list): list including any of
+        ['CDIPS', 'PATHOS', 'TASOC', '2minSPOC', 'eleanor']
+    """
+    for pipeline in pipelines:
+
+        get_method = methodDict[pipeline]
+
+        if pipeline in ['2minSPOC', 'eleanor']:
+            get_method(tic_id=tic_id, download_dir=download_dir)
+
+        elif pipeline in ['CDIPS', 'PATHOS', 'TASOC']:
+            get_method(tic_id=tic_id, hlsp_products=[pipeline],
+                       download_dir=download_dir)
+
+        else:
+            raise NotImplementedError

--- a/tests/test_alltesslightcurves.py
+++ b/tests/test_alltesslightcurves.py
@@ -1,0 +1,59 @@
+'''
+A test for the alltesslightcurves module.
+'''
+
+#############
+## IMPORTS ##
+#############
+
+from astrobase.services import alltesslightcurves
+
+try:
+    from astrobase.services import tesslightcurves
+
+    test_ok = (
+        tesslightcurves.lightkurve_dependency and
+        tesslightcurves.eleanor_dependency and
+        tesslightcurves.astroquery_dependency
+    )
+
+except Exception:
+    test_ok = False
+
+######################
+## TESTS TO EXECUTE ##
+######################
+
+if test_ok:
+
+    import os
+
+    #############
+    ## HELPERS ##
+    #############
+
+    def init_tempdir():
+
+        cwd = os.getcwd()
+        tempdir = os.path.join(cwd, 'temp_downloaddir')
+        if not os.path.exists(tempdir):
+            os.mkdir(tempdir)
+
+        return tempdir
+
+    def test_get_all_tess_lightcurves():
+
+        tic_id = '220314428'  # "V684 Mon"
+
+        tempdir = init_tempdir()
+
+        lcfile = alltesslightcurves.get_all_tess_lightcurves(
+            tic_id=tic_id,
+            pipelines=['CDIPS', 'PATHOS', 'TASOC', '2minSPOC', 'eleanor'],
+            download_dir=tempdir,
+        )
+
+        assert len(lcfile) == 5
+
+    if __name__ == "__main__":
+        test_get_all_tess_lightcurves()


### PR DESCRIPTION
I've been working on the same project as Luke over the past two days and this module should cover the third one of his ideas for improvements on astrobase.services.tesslightcurves.
This module wraps `get_two_minute_spoc_lightcurves()`, `get_eleanor_lightcurves()` and `get_hlsp_lightcurves()` into the function `get_all_tess_lightcurves()`. I've also written a separate test for it. 
Any comments would be appreciated.

